### PR TITLE
ci(tests): add deno workflow for testing and coverage reporting with codecov

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -2,9 +2,9 @@ name: Deno CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   test:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -12,7 +12,7 @@ jobs:
 
     env:
       DENO_DIR: .deno_cache
-      DENO_SKIP_TEST_PATTERNS: "**/npm/**,**/@jimp/**,**/registry.npmjs.org/**"
+      DENO_SKIP_TEST_PATTERNS: "**/.deno_cache/npm/**"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -2,61 +2,25 @@ name: Deno CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master]
-
-env:
-  DENO_DIR: .deno_cache
+    branches: [main]
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.canary }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        deno-version: [v2.x]
-        canary: [false]
-        include:
-          - deno-version: canary
-            os: ubuntu-latest
-            canary: true
+    runs-on: ubuntu-latest
+
+    env:
+      DENO_DIR: .deno_cache
 
     steps:
-      - name: Configure Git for Windows
-        if: matrix.os == 'windows-latest'
-        run: |
-          git config --system core.autocrlf false
-          git config --system core.eol lf
-
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup Deno
+      - name: Set up Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: ${{ matrix.deno-version }}
-
-      # Install system dependencies for canvas on Ubuntu
-      - name: Install canvas dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
-
-      # Install system dependencies for canvas on macOS
-      - name: Install canvas dependencies (macOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew install pkg-config cairo pango libpng jpeg giflib librsvg
-
-      # For Windows, we need to install additional tools
-      - name: Install canvas dependencies (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          npm install -g windows-build-tools
+          deno-version: v2.x
 
       - name: Cache Deno dependencies
         uses: actions/cache@v4
@@ -66,7 +30,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deno-
 
-      # Install npm dependencies with script execution permission
       - name: Install npm dependencies
         run: deno task npm:setup
 
@@ -76,16 +39,14 @@ jobs:
       - name: Lint code
         run: deno lint
 
-      - name: Run tests
-        run: deno test --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts
+      - name: Run tests with coverage
+        run: deno test --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage
 
       - name: Generate coverage report
-        if: matrix.os == 'ubuntu-latest' && matrix.deno-version == 'v2.x'
-        run: deno coverage --lcov cov/ > cov.lcov
+        run: deno coverage --lcov coverage > coverage.lcov
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.deno-version == 'v2.x'
         uses: codecov/codecov-action@v3
         with:
-          file: cov.lcov
+          file: ./coverage.lcov
           fail_ci_if_error: false

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -9,9 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+
     env:
       DENO_DIR: .deno_cache
-      DENO_SKIP_TEST_PATTERNS: "**/.deno_cache/**"
 
     steps:
       - name: Checkout repository
@@ -45,7 +45,7 @@ jobs:
         run: deno lint
 
       - name: Run tests with coverage
-        run: deno test tests --no-check --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage
+        run: deno test tests --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage
 
       - name: Generate coverage report
         run: deno coverage --lcov coverage > coverage.lcov

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Modify the test command to ignore npm modules
       - name: Run tests with coverage
-        run: deno test --no-check=npm: --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage
+        run: "deno test --no-check npm: --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage"
 
       - name: Generate coverage report
         run: deno coverage --lcov coverage > coverage.lcov

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -12,6 +12,8 @@ jobs:
 
     env:
       DENO_DIR: .deno_cache
+      # Skip test files in the npm packages
+      DENO_SKIP_TEST_PATTERNS: "@jimp/,npm:"
 
     steps:
       - name: Checkout repository
@@ -36,9 +38,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
-      # Instead of using npm directly, we'll use Deno's npm compatibility
+      # Use --no-check flag to skip type checking of npm modules
       - name: Setup npm packages with Deno
-        run: deno task npm:setup
+        run: deno cache --node-modules-dir --no-check npm:canvas@3.1.0 npm:gifencoder@2.0.1 npm:jimp@1.6.0 --reload
 
       - name: Check formatting
         run: deno fmt --check
@@ -46,8 +48,9 @@ jobs:
       - name: Lint code
         run: deno lint
 
+      # Modify the test command to ignore npm modules
       - name: Run tests with coverage
-        run: deno test --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage
+        run: deno test --no-check=npm: --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage
 
       - name: Generate coverage report
         run: deno coverage --lcov coverage > coverage.lcov

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -45,7 +45,7 @@ jobs:
         run: deno lint
 
       - name: Run tests with coverage
-        run: deno test --no-check --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage
+        run: deno test tests --no-check --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage
 
       - name: Generate coverage report
         run: deno coverage --lcov coverage > coverage.lcov

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,68 @@
+name: Deno CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+env:
+  DENO_DIR: .deno_cache
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.canary }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        deno-version: [v2.x]
+        canary: [false]
+        include:
+          - deno-version: canary
+            os: ubuntu-latest
+            canary: true
+
+    steps:
+      - name: Configure Git for Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          git config --system core.autocrlf false
+          git config --system core.eol lf
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.deno-version }}
+
+      - name: Cache Deno dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.DENO_DIR }}
+          key: ${{ runner.os }}-deno-${{ hashFiles('deno.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-deno-
+
+      - name: Check formatting
+        run: deno fmt --check
+
+      - name: Lint code
+        run: deno lint
+
+      - name: Run tests
+        run: deno test --allow-all --coverage=cov/
+
+      - name: Generate coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.deno-version == 'v2.x'
+        run: deno coverage --lcov cov/ > cov.lcov
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.deno-version == 'v2.x'
+        uses: codecov/codecov-action@v3
+        with:
+          file: cov.lcov
+          fail_ci_if_error: false

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -39,6 +39,25 @@ jobs:
         with:
           deno-version: ${{ matrix.deno-version }}
 
+      # Install system dependencies for canvas on Ubuntu
+      - name: Install canvas dependencies (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+
+      # Install system dependencies for canvas on macOS
+      - name: Install canvas dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install pkg-config cairo pango libpng jpeg giflib librsvg
+
+      # For Windows, we need to install additional tools
+      - name: Install canvas dependencies (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          npm install -g windows-build-tools
+
       - name: Cache Deno dependencies
         uses: actions/cache@v4
         with:
@@ -47,6 +66,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deno-
 
+      # Install npm dependencies with script execution permission
+      - name: Install npm dependencies
+        run: deno task npm:setup
+
       - name: Check formatting
         run: deno fmt --check
 
@@ -54,7 +77,7 @@ jobs:
         run: deno lint
 
       - name: Run tests
-        run: deno test --allow-all --coverage=cov/
+        run: deno test --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts
 
       - name: Generate coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.deno-version == 'v2.x'

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Run tests with coverage
       - name: Run tests with coverage
-        run: "deno test --no-check --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage"
+        run: "deno test --no-check --exclude=.deno_cache --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage"
 
       - name: Generate coverage report
         run: deno coverage --lcov coverage > coverage.lcov

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -50,7 +50,7 @@ jobs:
 
       # Modify the test command to ignore npm modules
       - name: Run tests with coverage
-        run: "deno test --no-check npm: --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage"
+        run: "deno test --no-check --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage"
 
       - name: Generate coverage report
         run: deno coverage --lcov coverage > coverage.lcov

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -12,8 +12,7 @@ jobs:
 
     env:
       DENO_DIR: .deno_cache
-      # Skip test files in the npm packages
-      DENO_SKIP_TEST_PATTERNS: "@jimp/,npm:"
+      DENO_SKIP_TEST_PATTERNS: "**/npm/**,**/@jimp/**,**/registry.npmjs.org/**"
 
     steps:
       - name: Checkout repository
@@ -48,7 +47,7 @@ jobs:
       - name: Lint code
         run: deno lint
 
-      # Modify the test command to ignore npm modules
+      # Run tests with coverage
       - name: Run tests with coverage
         run: "deno test --no-check --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage"
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -9,10 +9,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
     env:
       DENO_DIR: .deno_cache
-      DENO_SKIP_TEST_PATTERNS: "**/.deno_cache/npm/**"
+      DENO_SKIP_TEST_PATTERNS: "**/.deno_cache/**"
 
     steps:
       - name: Checkout repository
@@ -31,13 +30,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deno-
 
-      # Install system dependencies required for canvas
       - name: Install system dependencies for canvas
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
-      # Use --no-check flag to skip type checking of npm modules
       - name: Setup npm packages with Deno
         run: deno cache --node-modules-dir --no-check npm:canvas@3.1.0 npm:gifencoder@2.0.1 npm:jimp@1.6.0 --reload
 
@@ -47,9 +44,8 @@ jobs:
       - name: Lint code
         run: deno lint
 
-      # Run tests with coverage
       - name: Run tests with coverage
-        run: "deno test --no-check --exclude=.deno_cache --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage"
+        run: deno test --no-check --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=coverage
 
       - name: Generate coverage report
         run: deno coverage --lcov coverage > coverage.lcov

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -22,15 +22,6 @@ jobs:
         with:
           deno-version: v2.x
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "20"
-          cache: "npm"
-
-      - name: Install Node.js dependencies
-        run: npm install
-
       - name: Cache Deno dependencies
         uses: actions/cache@v4
         with:
@@ -39,13 +30,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deno-
 
-      # Install build tools needed for canvas
-      - name: Install build dependencies
+      # Install system dependencies required for canvas
+      - name: Install system dependencies for canvas
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
-      - name: Setup npm cache for Deno
+      # Instead of using npm directly, we'll use Deno's npm compatibility
+      - name: Setup npm packages with Deno
         run: deno task npm:setup
 
       - name: Check formatting

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           deno-version: v2.x
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install Node.js dependencies
+        run: npm install
+
       - name: Cache Deno dependencies
         uses: actions/cache@v4
         with:
@@ -30,7 +39,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deno-
 
-      - name: Install npm dependencies
+      # Install build tools needed for canvas
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+
+      - name: Setup npm cache for Deno
         run: deno task npm:setup
 
       - name: Check formatting

--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,7 @@
   "imports": {
     "@std/assert": "jsr:@std/assert@1"
   },
-  "nodeModulesDir": true,
+  "nodeModulesDir": "auto",
   "fmt": {
     "useTabs": false,
     "lineWidth": 80,

--- a/deno.json
+++ b/deno.json
@@ -4,8 +4,7 @@
     "dev:example": "deno run --allow-ffi --allow-read --allow-write example.ts",
     "tidy": "deno fmt && deno lint",
     "test": "deno test --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts",
-    "llm": "bash utils/repo.sh",
-    "npm:setup": "deno cache --node-modules-dir npm:canvas@3.1.0 npm:gifencoder@2.0.1 npm:jimp@1.6.0 --reload"
+    "llm": "bash utils/repo.sh"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1"

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
     "dev": "deno run --watch main.ts",
     "dev:example": "deno run --allow-ffi --allow-read --allow-write example.ts",
     "tidy": "deno fmt && deno lint",
-    "test": "deno test --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts",
+    "test": "deno test --allow-ffi --allow-read --allow-write --allow-scripts",
     "llm": "bash utils/repo.sh"
   },
   "imports": {

--- a/deno.json
+++ b/deno.json
@@ -3,13 +3,14 @@
     "dev": "deno run --watch main.ts",
     "dev:example": "deno run --allow-ffi --allow-read --allow-write example.ts",
     "tidy": "deno fmt && deno lint",
-    "test": "deno test --allow-ffi --allow-read --allow-write",
-    "llm": "bash utils/repo.sh"
+    "test": "deno test --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts",
+    "llm": "bash utils/repo.sh",
+    "npm:setup": "deno cache --node-modules-dir npm:canvas@3.1.0 npm:gifencoder@2.0.1 npm:jimp@1.6.0 --reload"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1"
   },
-  "nodeModulesDir": "auto",
+  "nodeModulesDir": true,
   "fmt": {
     "useTabs": false,
     "lineWidth": 80,


### PR DESCRIPTION
This pull request introduces a new CI workflow for Deno and updates the test script in `deno.json` to include an additional permission. The most important changes are as follows:

### CI Workflow Setup

* [`.github/workflows/deno.yml`](diffhunk://#diff-4b320e75cc37bb8ab3a2ffd48787af06226cfd841a278e984228101a5ffaa0aeR1-R57): Added a new GitHub Actions workflow for Deno CI, which includes steps for setting up Deno, caching dependencies, installing system dependencies, checking formatting, linting code, running tests with coverage, generating a coverage report, and uploading the coverage report to Codecov.

### Script Updates

* [`deno.json`](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL6-R6): Updated the `test` script to include the `--allow-scripts` permission, ensuring that tests can run scripts as needed.