### PR TITLE
feat(transforms): add base TransformOptions system with standardized resizing and refactor core transforms

### DIFF
--- a/src/transforms/blink.ts
+++ b/src/transforms/blink.ts
@@ -1,6 +1,6 @@
 import { Frame, GIF, Image } from '@matmen/imagescript';
 import { BlinkParams, TransformResult } from '@/types.ts';
-import { resolveAsset } from '@/utils.ts';
+import { applyBaseTransforms, resolveAsset } from '@/utils.ts';
 import {
     InvalidImageError,
     ProcessingError,
@@ -10,13 +10,13 @@ import {
 export async function blink(params: BlinkParams): Promise<TransformResult> {
     const { inputs, options } = params;
 
-    if (!inputs || inputs.length < 2) {
+    if (!inputs?.length || inputs.length < 2) {
         throw new ProcessingError(
             'At least 2 images required for blink animation',
         );
     }
 
-    const duration = Math.max(0, options?.delay ?? 200);
+    const delay = Math.max(50, options?.delay ?? 200);
     const loop = options?.loop !== false;
 
     try {
@@ -24,36 +24,32 @@ export async function blink(params: BlinkParams): Promise<TransformResult> {
             inputs.map((input) => resolveAsset(input)),
         );
 
-        const images = await Promise.all(
-            resolvedPaths.map((path) => {
-                return Deno.readFile(path).then((buffer) =>
-                    Image.decode(buffer)
-                );
+        const originalImages: Image[] = await Promise.all(
+            resolvedPaths.map(async (path) => {
+                const buffer = await Deno.readFile(path);
+                return await Image.decode(buffer);
             }),
+        );
+
+        const images = originalImages.map((img) =>
+            applyBaseTransforms(img, options)
         );
 
         const firstImage = images[0];
         const { width, height } = firstImage;
 
-        // all images where dimensions don't match
-        // are resized to match the first image
-        const resizedFrames: Frame[] = images.map((img) => {
-            let processedImg = img;
-            if (img.width !== width || img.height !== height) {
-                processedImg = img.fit(width, height);
-            }
+        const frames: Frame[] = images.map((img) => {
+            const processedImg = (img.width !== width || img.height !== height)
+                ? img.fit(width, height)
+                : img;
+
             const frame = new Frame(width, height);
             frame.composite(processedImg, 0, 0);
+            frame.duration = delay;
             return frame;
         });
 
-        resizedFrames.forEach((frame) => {
-            frame.duration = duration;
-        });
-
-        const loopCount = loop ? -1 : 0;
-        const gif = new GIF(resizedFrames, loopCount);
-
+        const gif = new GIF(frames, loop ? -1 : 0);
         return await gif.encode();
     } catch (error) {
         if (error instanceof InvalidImageError) {

--- a/src/transforms/blink.ts
+++ b/src/transforms/blink.ts
@@ -40,7 +40,7 @@ export async function blink(params: BlinkParams): Promise<TransformResult> {
         const resizedFrames: Frame[] = images.map((img) => {
             let processedImg = img;
             if (img.width !== width || img.height !== height) {
-                processedImg = img.resize(width, height);
+                processedImg = img.fit(width, height);
             }
             const frame = new Frame(width, height);
             frame.composite(processedImg, 0, 0);

--- a/src/transforms/circle.ts
+++ b/src/transforms/circle.ts
@@ -1,23 +1,25 @@
 import { Image } from '@matmen/imagescript';
-import { CircleParams, TransformResult } from '@/types.ts';
-import { resolveAsset } from '@/utils.ts';
-import { ProcessingError, throwProcessingError } from '@/errors.ts';
 import { parseHex } from '@temelj/color';
+import { CircleParams, TransformResult } from '@/types.ts';
+import { applyBaseTransforms, loadImage, resolveAsset } from '@/utils.ts';
+import { ProcessingError, throwProcessingError } from '@/errors.ts';
 
 export async function circle(params: CircleParams): Promise<TransformResult> {
     try {
         const resolvedPath = await resolveAsset(params.input);
-        const buffer = await Deno.readFile(resolvedPath);
+        const originalImage = await loadImage(resolvedPath);
 
-        const image = await Image.decode(buffer);
+        const image = applyBaseTransforms(originalImage, params.options);
 
         if (image.width === 0 || image.height === 0) {
             throw new ProcessingError('Image has zero dimensions');
         }
 
-        const size = Math.min(image.width, image.height);
         const options = params.options;
         const borderWidth = Math.max(0, options?.borderWidth || 0);
+
+        // smaller dimension is used to ensure we can fit a circle
+        const size = Math.min(image.width, image.height);
 
         let processedImage = image;
         if (image.width !== size || image.height !== size) {
@@ -32,8 +34,8 @@ export async function circle(params: CircleParams): Promise<TransformResult> {
                 options?.borderColor,
             );
         } else {
-            processedImage = processedImage.cropCircle();
-            return await processedImage.encode();
+            const circularImage = processedImage.cropCircle();
+            return await circularImage.encode();
         }
     } catch (error) {
         throwProcessingError(error, 'Failed to apply circle transform');
@@ -65,25 +67,16 @@ async function createCircleWithBorder(
 
     borderedImage.fill(0x00000000); // transparent background
 
-    const borderRadius = borderSize / 2;
-    const innerRadius = borderRadius - borderWidth;
+    const centerX = borderSize / 2;
+    const centerY = borderSize / 2;
+    const outerRadius = borderSize / 2;
+    const innerRadius = outerRadius - borderWidth;
 
-    borderedImage.drawCircle(
-        borderRadius,
-        borderRadius,
-        borderRadius,
-        borderColorRGBA,
-    );
+    borderedImage.drawCircle(centerX, centerY, outerRadius, borderColorRGBA);
 
-    borderedImage.drawCircle(
-        borderRadius,
-        borderRadius,
-        innerRadius,
-        0x00000000,
-    );
+    borderedImage.drawCircle(centerX, centerY, innerRadius, 0x00000000);
 
     const circularImage = image.cropCircle();
-
     borderedImage.composite(circularImage, borderWidth, borderWidth);
 
     const finalImage = borderedImage.cropCircle();

--- a/src/transforms/circle.ts
+++ b/src/transforms/circle.ts
@@ -4,8 +4,6 @@ import { resolveAsset } from '@/utils.ts';
 import { ProcessingError, throwProcessingError } from '@/errors.ts';
 import { parseHex } from '@temelj/color';
 
-const MAX_IMAGE_SIZE = 4096;
-
 export async function circle(params: CircleParams): Promise<TransformResult> {
     try {
         const resolvedPath = await resolveAsset(params.input);
@@ -17,21 +15,9 @@ export async function circle(params: CircleParams): Promise<TransformResult> {
             throw new ProcessingError('Image has zero dimensions');
         }
 
-        if (image.width > MAX_IMAGE_SIZE || image.height > MAX_IMAGE_SIZE) {
-            throw new ProcessingError(
-                `Image too large: ${image.width}x${image.height}px`,
-            );
-        }
-
         const size = Math.min(image.width, image.height);
         const options = params.options;
         const borderWidth = Math.max(0, options?.borderWidth || 0);
-
-        if (size + (borderWidth * 2) > MAX_IMAGE_SIZE) {
-            throw new ProcessingError(
-                `Resulting image size too large: ${size + (borderWidth * 2)}px`,
-            );
-        }
 
         let processedImage = image;
         if (image.width !== size || image.height !== size) {

--- a/src/transforms/color.ts
+++ b/src/transforms/color.ts
@@ -1,76 +1,75 @@
 import { Image } from '@matmen/imagescript';
 import { fromRgb, hslToRgb, parseHex, rgbToHsl } from '@temelj/color';
 import { ColorParams, TransformResult } from '@/types.ts';
-import { loadImage, resolveAsset } from '@/utils.ts';
+import { applyBaseTransforms, loadImage, resolveAsset } from '@/utils.ts';
 import { ProcessingError, throwProcessingError } from '@/errors.ts';
 
 const INV_255 = 1 / 255;
-const DEFAULT_INTENSITY = 1;
-const DEFAULT_OPACITY = 0.3;
-const DEFAULT_HEX = '#ffffff';
-const MIN_INTENSITY = 0;
-const MAX_INTENSITY = 1;
-const MIN_OPACITY = 0;
-const MAX_OPACITY = 1;
+const DEFAULTS = { INTENSITY: 1.0, OPACITY: 0.3, HEX: '#ffffff' } as const;
+const BOUNDS = { INTENSITY: [0, 1], OPACITY: [0, 1] } as const;
 
-function softLightBlend(b: number, s: number): number {
-    if (s < 0.5) {
-        return b - (1 - 2 * s) * b * (1 - b);
-    } else {
-        const d = b <= 0.25 ? ((16 * b - 12) * b + 4) * b : Math.sqrt(b);
-        return b + (2 * s - 1) * (d - b);
-    }
+function clamp(value: number, [min, max]: readonly [number, number]): number {
+    return Math.max(min, Math.min(max, value));
+}
+
+function softLightBlend(base: number, overlay: number): number {
+    return overlay < 0.5
+        ? base - (1 - 2 * overlay) * base * (1 - base)
+        : base + (2 * overlay - 1) * (
+                    base <= 0.25
+                        ? ((16 * base - 12) * base + 4) * base
+                        : Math.sqrt(base)
+                ) -
+            base;
 }
 
 export async function color(params: ColorParams): Promise<TransformResult> {
     try {
-        const options = params.options ?? {};
+        const options = params.options;
         const mode = options.blendMode ?? 'tint';
-        const intensity = typeof options.intensity === 'number'
-            ? Math.max(
-                MIN_INTENSITY,
-                Math.min(MAX_INTENSITY, options.intensity),
-            )
-            : DEFAULT_INTENSITY;
+        const intensity = clamp(
+            options.intensity ?? DEFAULTS.INTENSITY,
+            BOUNDS.INTENSITY,
+        );
+        const opacity = clamp(
+            options.opacity ?? DEFAULTS.OPACITY,
+            BOUNDS.OPACITY,
+        );
+        const hex = options.hex ?? DEFAULTS.HEX;
 
-        const hex = options.hex ?? DEFAULT_HEX;
         const tintRgb = parseHex(hex);
-
         if (!tintRgb) {
             throw new ProcessingError(`Invalid hex color: ${hex}`);
         }
 
-        const tr255 = tintRgb.red;
-        const tg255 = tintRgb.green;
-        const tb255 = tintRgb.blue;
+        const { red: tr255, green: tg255, blue: tb255 } = tintRgb;
 
-        let tr: number;
-        let tg: number;
-        let tb: number;
+        const resolvedPath = await resolveAsset(params.input);
+        const originalImage = await loadImage(resolvedPath);
 
-        let tH: number;
-        let tS: number;
+        const src = applyBaseTransforms(originalImage, params.options);
+
+        let tint: { h: number; s: number } | {
+            r: number;
+            g: number;
+            b: number;
+        };
 
         if (mode === 'tint') {
             const tintHsl = rgbToHsl(tintRgb);
-            tH = tintHsl.hue;
-            tS = tintHsl.saturation;
-        } else if (mode === 'softlight') {
-            tr = tr255 * INV_255;
-            tg = tg255 * INV_255;
-            tb = tb255 * INV_255;
+            tint = { h: tintHsl.hue, s: tintHsl.saturation };
+        } else {
+            tint = {
+                r: tr255 * INV_255,
+                g: tg255 * INV_255,
+                b: tb255 * INV_255,
+            };
         }
 
-        const washOpacity = typeof options.opacity === 'number'
-            ? Math.max(MIN_OPACITY, Math.min(MAX_OPACITY, options.opacity))
-            : DEFAULT_OPACITY;
+        const oneMinusOpacity = 1 - opacity;
+        const oneMinusIntensity = 1 - intensity;
 
-        const resolvedPath = await resolveAsset(params.input);
-        const src = await loadImage(resolvedPath);
         const out = new Image(src.width, src.height);
-
-        const oneMinusWashOpacity = 1 - washOpacity;
-
         out.fill((x: number, y: number) => {
             const [origR, origG, origB, origA] = src.getRGBAAt(x, y);
 
@@ -78,55 +77,47 @@ export async function color(params: ColorParams): Promise<TransformResult> {
             let finalG = origG;
             let finalB = origB;
 
-            if (mode === 'wash') {
-                finalR =
-                    ((tr255 * washOpacity) + (origR * oneMinusWashOpacity)) | 0;
-                finalG =
-                    ((tg255 * washOpacity) + (origG * oneMinusWashOpacity)) | 0;
-                finalB =
-                    ((tb255 * washOpacity) + (origB * oneMinusWashOpacity)) | 0;
-            } else if (
-                mode === 'tint' && tH !== undefined && tS !== undefined
-            ) {
-                const srcHsl = rgbToHsl(fromRgb(origR, origG, origB));
-                const sl = srcHsl.lightness;
-                const tinted = hslToRgb({
-                    hue: tH,
-                    saturation: tS,
-                    lightness: sl,
-                    alpha: 1,
-                });
-                finalR = tinted.red;
-                finalG = tinted.green;
-                finalB = tinted.blue;
-            } else if (
-                mode === 'softlight' && tr !== undefined && tg !== undefined &&
-                tb !== undefined
-            ) {
-                const br = origR * INV_255;
-                const bg = origG * INV_255;
-                const bb = origB * INV_255;
-                const rr = softLightBlend(br, tr);
-                const rg = softLightBlend(bg, tg);
-                const rb = softLightBlend(bb, tb);
-                finalR = (rr * 255) | 0;
-                finalG = (rg * 255) | 0;
-                finalB = (rb * 255) | 0;
+            switch (mode) {
+                case 'wash':
+                    finalR = (tr255 * opacity + origR * oneMinusOpacity) | 0;
+                    finalG = (tg255 * opacity + origG * oneMinusOpacity) | 0;
+                    finalB = (tb255 * opacity + origB * oneMinusOpacity) | 0;
+                    break;
+
+                case 'tint':
+                    if ('h' in tint) {
+                        const srcHsl = rgbToHsl(fromRgb(origR, origG, origB));
+                        const tinted = hslToRgb({
+                            hue: tint.h,
+                            saturation: tint.s,
+                            lightness: srcHsl.lightness,
+                            alpha: 1,
+                        });
+                        finalR = tinted.red;
+                        finalG = tinted.green;
+                        finalB = tinted.blue;
+                    }
+                    break;
+
+                case 'softlight':
+                    if ('r' in tint) {
+                        const br = origR * INV_255;
+                        const bg = origG * INV_255;
+                        const bb = origB * INV_255;
+                        finalR = (softLightBlend(br, tint.r) * 255) | 0;
+                        finalG = (softLightBlend(bg, tint.g) * 255) | 0;
+                        finalB = (softLightBlend(bb, tint.b) * 255) | 0;
+                    }
+                    break;
             }
 
-            if (intensity <= MIN_INTENSITY) {
-                return Image.rgbaToColor(origR, origG, origB, origA);
-            } else if (intensity >= MAX_INTENSITY) {
-                return Image.rgbaToColor(finalR, finalG, finalB, origA);
-            } else {
-                const rMix =
-                    ((origR * (1 - intensity)) + (finalR * intensity)) | 0;
-                const gMix =
-                    ((origG * (1 - intensity)) + (finalG * intensity)) | 0;
-                const bMix =
-                    ((origB * (1 - intensity)) + (finalB * intensity)) | 0;
-                return Image.rgbaToColor(rMix, gMix, bMix, origA);
+            if (intensity < 1) {
+                finalR = (origR * oneMinusIntensity + finalR * intensity) | 0;
+                finalG = (origG * oneMinusIntensity + finalG * intensity) | 0;
+                finalB = (origB * oneMinusIntensity + finalB * intensity) | 0;
             }
+
+            return Image.rgbaToColor(finalR, finalG, finalB, origA);
         });
 
         return await out.encode();

--- a/src/transforms/greyscale.ts
+++ b/src/transforms/greyscale.ts
@@ -1,5 +1,5 @@
 import { GreyscaleParams, TransformResult } from '@/types.ts';
-import { loadImage, resolveAsset } from '@/utils.ts';
+import { applyBaseTransforms, loadImage, resolveAsset } from '@/utils.ts';
 import { InvalidImageError, throwProcessingError } from '@/errors.ts';
 
 export async function greyscale(
@@ -7,10 +7,11 @@ export async function greyscale(
 ): Promise<TransformResult> {
     try {
         const resolvedPath = await resolveAsset(params.input);
-        const image = await loadImage(resolvedPath);
+        const originalImage = await loadImage(resolvedPath);
+
+        const image = applyBaseTransforms(originalImage, params.options);
 
         const greyImage = image.saturation(0);
-
         return await greyImage.encode();
     } catch (error) {
         if (error instanceof InvalidImageError) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,31 +1,49 @@
+export interface ResizeOptions {
+    width?: number;
+    height?: number;
+    mode?: string;
+}
+
+export interface TransformOptions {
+    resize?: ResizeOptions;
+}
+
 export interface GreyscaleParams {
     input: string;
+    options?: TransformOptions;
 }
 
 export interface ColorParams {
     input: string;
-    options: {
-        hex?: string;
-        blendMode?: 'tint' | 'softlight' | 'wash';
-        opacity?: number;
-        intensity?: number;
-    };
+    options: ColorOptions & TransformOptions;
+}
+
+export interface ColorOptions {
+    hex?: string;
+    blendMode?: 'tint' | 'softlight' | 'wash';
+    opacity?: number;
+    intensity?: number;
 }
 
 export interface CircleParams {
     input: string;
-    options?: {
-        borderWidth?: number;
-        borderColor?: string;
-    };
+    options?: CircleOptions & TransformOptions;
+}
+
+export interface CircleOptions {
+    borderWidth?: number;
+    borderColor?: string;
 }
 
 export interface BlinkParams {
     inputs: string[];
-    options?: {
-        delay?: number;
-        loop?: boolean;
-    };
+    options?: BlinkOptions & TransformOptions;
+}
+
+export interface BlinkOptions {
+    delay?: number;
+    loop?: boolean;
+    maxConcurrent?: number;
 }
 
 export type TransformResult = Uint8Array;


### PR DESCRIPTION
This patch introduces a unified system for applying base transforms (e.g., resizing) across all image transforms. The new `TransformOptions` interface provides standardized option handling and ensures consistency in preprocessing.

Changes include:

* Core types and utilities
  * Add `TransformOptions` and per-transform option interfaces (`ResizeOptions`, `ColorOptions`, `CircleOptions`, `BlinkOptions`) in `types.ts`.
  * Add `applyBaseTransforms()` in `utils.ts` to handle resizing before transform-specific logic.

* Transform updates
  * blink: switch from `resize` to `fit`, improve frame duration handling, and validate delay/loop options.
  * circle: clarify circular crop and border drawing, remove redundant size checks.
  * color: simplify option handling, improve clamping, and refactor blending logic (tint, wash, softlight).
  * greyscale: standardized to use `applyBaseTransforms()`.

* Image loading and validation
  * Improve format validation by caching validated paths and simplifying signature checks.
  * Streamline image loading and error handling.