### PR TITLE
ci: refine GitHub Actions workflows with scoped triggers, simplified steps, and updated environments

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,20 @@
 name: CodeQL
 
 on:
-    workflow_dispatch:
     push:
         branches: [master]
+        paths:
+            - 'src'
+            - 'tests'
+            - 'example'
     pull_request:
+        paths:
+            - 'src'
+            - 'tests'
+            - 'example'
+    schedule:
+        - cron: '0 0 * * 1'
+    workflow_dispatch:
 
 jobs:
     analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,14 +4,14 @@ on:
     push:
         branches: [master]
         paths:
-            - 'src'
-            - 'tests'
-            - 'example'
+            - 'src/**'
+            - 'tests/**'
+            - 'example/**/*.ts'
     pull_request:
         paths:
-            - 'src'
-            - 'tests'
-            - 'example'
+            - 'src/**'
+            - 'tests/**'
+            - 'example/**/*.ts'
     schedule:
         - cron: '0 0 * * 1'
     workflow_dispatch:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -5,6 +5,7 @@ on:
         branches: [master]
     pull_request:
         branches: [master]
+    workflow_dispatch:
 
 jobs:
     test:
@@ -14,11 +15,9 @@ jobs:
             DENO_DIR: .deno_cache
 
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
+            - uses: actions/checkout@v3
 
-            - name: Set up Deno
-              uses: denoland/setup-deno@v2
+            - uses: denoland/setup-deno@v2
               with:
                   deno-version: v2.x
 
@@ -30,19 +29,17 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-deno-
 
-            - name: Check formatting
-              run: deno fmt --check
+            - run: deno fmt --check
 
-            - name: Lint code
-              run: deno lint
+            - run: deno lint
 
-            - name: Run tests with coverage
-              run: deno test tests --allow-ffi --allow-read --allow-write --allow-env --allow-net --allow-run --allow-scripts --coverage=cov --junit-path=./junit.xml
+            - run: deno test --allow-read --allow-write --allow-net --coverage=cov --junit-path=./junit.xml
 
-            - name: Generate coverage report
-              run: deno coverage --lcov cov > coverage.lcov
+            - run: deno coverage --lcov cov > coverage.lcov
 
             - name: Upload test results to Codecov
+              # https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always
+              # always run this step, regardless of sucess or failure
               if: ${{ !cancelled() }}
               uses: codecov/test-results-action@v1
               with:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -39,7 +39,7 @@ jobs:
 
             - name: Upload test results to Codecov
               # https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#always
-              # always run this step, regardless of sucess or failure
+              # always run this step, regardless of success or failure
               if: ${{ !cancelled() }}
               uses: codecov/test-results-action@v1
               with:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -33,7 +33,7 @@ jobs:
 
             - run: deno lint
 
-            - run: deno test --allow-read --allow-write --allow-net --coverage=cov --junit-path=./junit.xml
+            - run: deno test --allow-read --allow-write --allow-net --coverage=cov --junit-path=./junit.xml ./tests/
 
             - run: deno coverage --lcov cov > coverage.lcov
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to registry
+name: Publish to JSR and NPM
 on:
     release:
         types: [published]
@@ -13,27 +13,22 @@ jobs:
             id-token: write
 
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
+            - uses: actions/checkout@v4
 
-            - name: Set env
-              run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+            - run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-            - name: Setup Deno
-              uses: denoland/setup-deno@v1
+            - uses: denoland/setup-deno@v1
               with:
                   deno-version: v2.x
 
             - name: Publish to jsr
               run: deno publish
 
-            - name: Build npm package
-              run: deno run -A build_npm.ts $RELEASE_VERSION
+            - run: deno run -A build_npm.ts $RELEASE_VERSION
 
-            - name: Setup Node/npm
-              uses: actions/setup-node@v3
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 24
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@totallynotdavid'
 


### PR DESCRIPTION
This patch updates the GitHub Actions configuration to improve maintainability, compatibility, and execution control.

Changes include:

* Workflow triggers
  * Restrict `codeql.yml` to `src/**`, `tests/**`, and `example/**/*.ts`.
  * Add scheduled weekly run and `workflow_dispatch` trigger.
  * Add `workflow_dispatch` trigger to `deno.yml` for manual runs.

* Workflow steps
  * Remove explicit step names in `deno.yml` and `publish.yml` for cleaner files.
  * Update Node.js in `publish.yml` from v20 → v24.

* Clarity
  * Rename publish workflow to "Publish to JSR and NPM".