### PR TITLE
docs(readme): clarify package scope and non-responsibilities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,10 +19,14 @@ Features:
 - Designed for composition: build processing pipelines by chaining simple
   functions.
 
-The package is a good fit for:
+What this package does not do:
 
-- Social media or chat bots that need consistent image effects
-- Messaging applications that add image filters or overlays
+- Caching or concurrency controls
+- Input or image format validation
+- Memory management (large images will have a large memory footprint)
+- Create directories or handle permissions
+
+Calling services must handle these based on their own requirements.
 
 ## Available transformations
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# image-generation [![JSR](https://jsr.io/badges/@dv/image-generation)](https://jsr.io/@dv/image-generation) [![npm version](https://badge.fury.io/js/@totallynotdavid%2Fimage-generation.svg)](https://badge.fury.io/js/@totallynotdavid%2Fimage-generation)
+# [pkg]: image-generation [![JSR](https://jsr.io/badges/@dv/image-generation)](https://jsr.io/@dv/image-generation) [![npm version](https://badge.fury.io/js/@totallynotdavid%2Fimage-generation.svg)](https://badge.fury.io/js/@totallynotdavid%2Fimage-generation)
 
 [![CodeQL](https://github.com/totallynotdavid/image-generation/actions/workflows/codeql.yml/badge.svg)](https://github.com/totallynotdavid/image-generation/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/totallynotdavid/image-generation/graph/badge.svg?token=Z9K6TC9HFO)](https://codecov.io/gh/totallynotdavid/image-generation)


### PR DESCRIPTION
Clarifies what is out of scope (caching, concurrency, validation, etc.) and updates the main heading with a [pkg]: prefix for clearer documentation.