### PR TITLE
fix(color): apply opacity correctly for tint and softlight blend modes

### DIFF
--- a/src/transforms/color.ts
+++ b/src/transforms/color.ts
@@ -88,9 +88,12 @@ export async function color(params: ColorParams): Promise<TransformResult> {
                         lightness: srcHsl.lightness,
                         alpha: 1,
                     });
-                    finalR = tinted.red;
-                    finalG = tinted.green;
-                    finalB = tinted.blue;
+                    finalR = (tinted.red * opacity + origR * oneMinusOpacity) |
+                        0;
+                    finalG =
+                        (tinted.green * opacity + origG * oneMinusOpacity) | 0;
+                    finalB = (tinted.blue * opacity + origB * oneMinusOpacity) |
+                        0;
                     break;
                 }
 
@@ -98,9 +101,12 @@ export async function color(params: ColorParams): Promise<TransformResult> {
                     const br = origR * INV_255;
                     const bg = origG * INV_255;
                     const bb = origB * INV_255;
-                    finalR = (softLightBlend(br, tint.tr) * 255) | 0;
-                    finalG = (softLightBlend(bg, tint.tg) * 255) | 0;
-                    finalB = (softLightBlend(bb, tint.tb) * 255) | 0;
+                    const softR = softLightBlend(br, tint.tr) * 255;
+                    const softG = softLightBlend(bg, tint.tg) * 255;
+                    const softB = softLightBlend(bb, tint.tb) * 255;
+                    finalR = (softR * opacity + origR * oneMinusOpacity) | 0;
+                    finalG = (softG * opacity + origG * oneMinusOpacity) | 0;
+                    finalB = (softB * opacity + origB * oneMinusOpacity) | 0;
                     break;
                 }
             }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -17,7 +17,7 @@ Deno.test('integration: should chain transforms (color -> greyscale)', async () 
     const coloredImage = await Image.decode(colorResult);
 
     const [r1, g1, b1, a1] = coloredImage.getRGBAAt(50, 50);
-    assertEquals([r1, g1, b1, a1], [0, 255, 0, 255]);
+    assertEquals([r1, g1, b1, a1], [127, 127, 0, 255]);
 
     // second transform: greyscale
     const greyResult = await greyscale({ input: colorResult });
@@ -25,7 +25,7 @@ Deno.test('integration: should chain transforms (color -> greyscale)', async () 
 
     assertEquals(greyImage.width, 100);
     const [r2, g2, b2, a2] = greyImage.getRGBAAt(50, 50);
-    assertEquals([r2, g2, b2, a2], [127, 127, 127, 255]);
+    assertEquals([r2, g2, b2, a2], [63, 63, 63, 255]);
 });
 
 Deno.test('integration: should chain transforms (circle -> color)', async () => {

--- a/tests/transforms/color.test.ts
+++ b/tests/transforms/color.test.ts
@@ -14,12 +14,12 @@ Deno.test('color: should apply basic tint', async () => {
         input: TestAssets.PATTERN,
         hex: '#0000ff',
         blendMode: 'tint',
-        opacity: 0.5, // TODO: seems to be ignored under tint
+        opacity: 0.5,
     });
 
     const image = await Image.decode(result);
     const [r, g, b, a] = Image.colorToRGBA(image.getPixelAt(10, 10));
-    assertEquals([r, g, b, a], [0, 0, 100, 255]);
+    assertEquals([r, g, b, a], [25, 25, 75, 255]);
 });
 
 Deno.test('color: applies wash blend mode', async () => {
@@ -40,13 +40,13 @@ Deno.test('color: should apply softlight blend mode', async () => {
         input: TestAssets.GRADIENT,
         hex: '#ff8800',
         blendMode: 'softlight',
-        opacity: 0.4, // TODO: seems to be ignored by softlight
+        opacity: 0.4,
         intensity: 0.8,
     });
 
     const image = await Image.decode(result);
     const [r, g, b, a] = Image.colorToRGBA(image.getPixelAt(10, 10));
-    assertEquals([r, g, b, a], [56, 7, 76, 255]);
+    assertEquals([r, g, b, a], [34, 15, 107, 255]);
 });
 
 Deno.test('color: should use default parameters', async () => {
@@ -61,7 +61,7 @@ Deno.test('color: should use default parameters', async () => {
 
     const image = await Image.decode(result);
     const [r, g, b, a] = Image.colorToRGBA(image.getPixelAt(10, 10));
-    assertEquals([r, g, b, a], [128, 128, 128, 255]);
+    assertEquals([r, g, b, a], [38, 38, 216, 255]);
 });
 
 Deno.test('color: should throw error on invalid hex color', async () => {
@@ -81,6 +81,64 @@ Deno.test('color: should throw error on invalid input', async () => {
         () => color({ input: TestAssets.NONEXISTENT }),
         ProcessingError,
         'Failed to load image',
+    );
+});
+
+Deno.test('color: opacity should affect tint blend mode', async () => {
+    const highOpacity = await color({
+        input: TestAssets.BLUE_SQUARE,
+        hex: '#ff0000',
+        blendMode: 'tint',
+        opacity: 0.5,
+    });
+
+    const lowOpacity = await color({
+        input: TestAssets.BLUE_SQUARE,
+        hex: '#ff0000',
+        blendMode: 'tint',
+        opacity: 0.45,
+    });
+
+    const [r1, g1, b1] = Image.colorToRGBA(
+        (await Image.decode(highOpacity)).getPixelAt(50, 50),
+    );
+    const [r2, g2, b2] = Image.colorToRGBA(
+        (await Image.decode(lowOpacity)).getPixelAt(50, 50),
+    );
+
+    assertEquals(
+        r1 !== r2 || g1 !== g2 || b1 !== b2,
+        true,
+        'Opacity should affect tint results',
+    );
+});
+
+Deno.test('color: opacity should affect softlight blend mode', async () => {
+    const highOpacity = await color({
+        input: TestAssets.GRADIENT,
+        hex: '#ff0000',
+        blendMode: 'softlight',
+        opacity: 0.5,
+    });
+
+    const lowOpacity = await color({
+        input: TestAssets.GRADIENT,
+        hex: '#ff0000',
+        blendMode: 'softlight',
+        opacity: 0.3,
+    });
+
+    const [r1, g1, b1] = Image.colorToRGBA(
+        (await Image.decode(highOpacity)).getPixelAt(50, 50),
+    );
+    const [r2, g2, b2] = Image.colorToRGBA(
+        (await Image.decode(lowOpacity)).getPixelAt(50, 50),
+    );
+
+    assertEquals(
+        r1 !== r2 || g1 !== g2 || b1 !== b2,
+        true,
+        'Opacity should affect softlight results',
     );
 });
 


### PR DESCRIPTION
This patch updates the `color` transform so that the `opacity` parameter is properly applied when using the `tint` and `softlight` blend modes. Colors are now blended with the original according to the specified opacity, ensuring expected results.

Changes include:
* Fix `src/transforms/color.ts` to apply opacity for `tint` and `softlight`.
* Update existing unit tests with corrected outputs for affected blend modes.
* Add new tests verifying opacity effects on `tint` and `softlight`.
* Adjust integration tests to reflect corrected color blending behavior.